### PR TITLE
Include `productsign` as allowed application 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         echo '${{ inputs.dev-id-installer-cert }}' | base64 -d > "$DEV_ID_INSTALLER"
 
         # Import cert to our specific keychain
-        security import "$DEV_ID_INSTALLER" -f pkcs12 -k "${{ steps.setup-keychain.outputs.keychain-path }}" -P "${{ inputs.dev-id-installer-password }}" -T /usr/bin/pkgbuild -T /usr/bin/security -T /usr/bin/productbuild
+        security import "$DEV_ID_INSTALLER" -f pkcs12 -k "${{ steps.setup-keychain.outputs.keychain-path }}" -P "${{ inputs.dev-id-installer-password }}" -T /usr/bin/pkgbuild -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign
 
         # Clean up temp files
         rm "$DEV_ID_INSTALLER"


### PR DESCRIPTION
Small change to include `productsign` as an allowed application for DEV_ID_INSTALLER. 

I may well be missing a reason why this shouldn't be included here - so apologies in advance. My use case is signing an installer created with [WhiteBox - Packages](http://s.sudre.free.fr/Software/Packages/about.html).

Let me know if you think it could be worthwhile including this - if so am happy to extend/add any tests.