### PR TITLE
Expose identity hash (useful for self-hosted)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,8 @@ jobs:
           - name: (self-hosted)
             os: self-hosted
     steps:
-      - uses: sudara/basic-macos-keychain-action@main
+      - uses: actions/checkout@v7
+      - uses: ./
         id: import
         continue-on-error: true # assume fail, let us run the upcoming step
         with:
@@ -44,7 +45,8 @@ jobs:
           - name: (self-hosted)
             os: self-hosted
     steps:
-      - uses: sudara/basic-macos-keychain-action@main
+      - uses: actions/checkout@v7
+      - uses: ./
         id: import
         continue-on-error: true # assume fail, let us run the upcoming step
         with:
@@ -90,7 +92,8 @@ jobs:
           - name: (self-hosted)
             os: self-hosted
     steps:
-      - uses: sudara/basic-macos-keychain-action@main
+      - uses: actions/checkout@v7
+      - uses: ./
         id: import
         with:
           dev-id-app-cert: ${{ secrets.DEVELOPER_ID_APP_CERT }}
@@ -124,7 +127,8 @@ jobs:
             os: self-hosted
 
     steps:
-      - uses: sudara/basic-macos-keychain-action@main
+      - uses: actions/checkout@v7
+      - uses: ./
         id: import
         with:
           dev-id-app-cert: ${{ secrets.DEVELOPER_ID_APP_CERT }}
@@ -189,7 +193,8 @@ jobs:
             os: self-hosted
 
     steps:
-      - uses: sudara/basic-macos-keychain-action@main
+      - uses: actions/checkout@v7
+      - uses: ./
         id: import
         with:
           dev-id-app-cert: ${{ secrets.DEVELOPER_ID_APP_CERT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,6 +194,63 @@ jobs:
           rm temp-product.pkg
           rm temp-hash.pkg
 
+  test-ambiguity:
+    name: TEST Ambiguity resolved by hash
+    runs-on: macos-latest
+    steps:
+      - name: Two valid same-named certs are ambiguous by name but resolvable by hash
+        run: |
+          set -eo pipefail
+          NAME="Developer ID Application: Ambiguity Test (TESTTEAM00)"
+          WORK="$(mktemp -d)"
+          printf '[req]\ndistinguished_name=dn\nx509_extensions=ext\nprompt=no\n[dn]\nCN=%s\n[ext]\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning\n' "$NAME" > "$WORK/openssl.cnf"
+
+          # two DIFFERENT certs (different keys) sharing one identity name
+          for n in A B; do
+            openssl req -x509 -newkey rsa:2048 -nodes -days 1 -keyout "$WORK/k$n.pem" -out "$WORK/c$n.pem" -config "$WORK/openssl.cnf" -extensions ext
+            openssl pkcs12 -export -out "$WORK/$n.p12" -inkey "$WORK/k$n.pem" -in "$WORK/c$n.pem" -passout pass:pw
+          done
+
+          KC="$HOME/Library/Keychains/ambiguity-test.keychain-db"
+          security create-keychain -p pw "$KC"
+          security unlock-keychain -p pw "$KC"
+          for n in A B; do
+            security import "$WORK/$n.p12" -f pkcs12 -k "$KC" -P pw -T /usr/bin/codesign
+          done
+          security set-key-partition-list -S apple-tool:,apple: -s -k pw "$KC" >/dev/null
+
+          # codesign only counts trusted certs as valid identity matches, so anchor both
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cA.pem"
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cB.pem"
+
+          echo "::group::valid codesigning identities"
+          security find-identity -v -p codesigning "$KC"
+          echo "::endgroup::"
+          COUNT="$(security find-identity -v -p codesigning "$KC" | grep -c "$NAME" || true)"
+          if [ "$COUNT" -lt 2 ]; then
+            echo "::error::expected at least 2 valid same-named identities, got $COUNT"
+            exit 1
+          fi
+
+          VICTIM="$WORK/victim"; cp /bin/ls "$VICTIM"
+
+          echo "=== signing by NAME should fail as ambiguous ==="
+          if codesign --force --keychain "$KC" -s "$NAME" "$VICTIM" 2>"$WORK/err.txt"; then
+            echo "::error::signing by name unexpectedly succeeded"; exit 1
+          fi
+          cat "$WORK/err.txt"
+          grep -q "ambiguous" "$WORK/err.txt" || { echo "::error::expected an 'ambiguous' error"; exit 1; }
+
+          echo "=== signing by HASH should succeed (same extraction the action uses) ==="
+          HASH="$(security find-identity -p codesigning "$KC" | grep -m1 "$NAME" | awk '{print $2}')"
+          echo "hash: $HASH"
+          codesign --force --keychain "$KC" -s "$HASH" "$VICTIM"
+          echo "OK: signing by hash resolved the ambiguity"
+
+      - name: Cleanup
+        if: always()
+        run: security delete-keychain "$HOME/Library/Keychains/ambiguity-test.keychain-db" || true
+
   test-cleanup-after-sign:
     if: ${{ always() }}
     name: TEST post-sign cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,6 +223,9 @@ jobs:
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cA.pem"
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cB.pem"
 
+          # codesign resolves -s by the search list, so the keychain must be in it (this is what the action's enable-keychain step does)
+          security list-keychains -d user -s "$KC"
+
           echo "::group::valid codesigning identities"
           security find-identity -v -p codesigning "$KC"
           echo "::endgroup::"
@@ -235,7 +238,7 @@ jobs:
           VICTIM="$WORK/victim"; cp /bin/ls "$VICTIM"
 
           echo "=== signing by NAME should fail as ambiguous ==="
-          if codesign --force --keychain "$KC" -s "$NAME" "$VICTIM" 2>"$WORK/err.txt"; then
+          if codesign --force -s "$NAME" "$VICTIM" 2>"$WORK/err.txt"; then
             echo "::error::signing by name unexpectedly succeeded"; exit 1
           fi
           cat "$WORK/err.txt"
@@ -244,7 +247,7 @@ jobs:
           echo "=== signing by HASH should succeed (same extraction the action uses) ==="
           HASH="$(security find-identity -p codesigning "$KC" | grep -m1 "$NAME" | awk '{print $2}')"
           echo "hash: $HASH"
-          codesign --force --keychain "$KC" -s "$HASH" "$VICTIM"
+          codesign --force -s "$HASH" "$VICTIM"
           echo "OK: signing by hash resolved the ambiguity"
 
       - name: Cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,12 @@
 name: tests
 
-# IMPORTANT: To remain secure for self-hosted runners
-# We disallow `pull_request` here
 on:
   push:
 
 jobs:
   test-no-cert:
-    name: TEST inputs ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
+    name: TEST inputs
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./
@@ -35,15 +26,8 @@ jobs:
           fi
 
   test-wrong-password:
-    name: TEST wrong pass ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
+    name: TEST wrong pass
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./
@@ -63,16 +47,9 @@ jobs:
           fi
 
   test-cleanup-after-fail:
-    name: TEST post-fail cleanup ${{ matrix.name }}
+    name: TEST post-fail cleanup
     needs: [test-wrong-password]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
+    runs-on: macos-latest
     steps:
       - name: Ensure no github-action* keychain exists
         run: |
@@ -82,15 +59,8 @@ jobs:
           fi
 
   test-keychain:
-    name: TEST Keychain create ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
+    name: TEST Keychain create
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./
@@ -116,16 +86,8 @@ jobs:
           fi
 
   test-sign:
-    name: TEST Sign ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
-
+    name: TEST Sign
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./
@@ -182,16 +144,8 @@ jobs:
           rm $TEMP_FILE
 
   test-installer-sign:
-    name: TEST Installer Sign ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
-
+    name: TEST Installer Sign
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./
@@ -242,16 +196,9 @@ jobs:
 
   test-cleanup-after-sign:
     if: ${{ always() }}
-    name: TEST post-sign cleanup ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    name: TEST post-sign cleanup
+    runs-on: macos-latest
     needs: test-sign
-    strategy:
-      matrix:
-        include:
-          - name: (hosted)
-            os: macos-latest
-          - name: (self-hosted)
-            os: self-hosted
     steps:
       - name: Ensure no github-action* keychain exists
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,12 +206,12 @@ jobs:
           KC="$HOME/Library/Keychains/ambiguity-test.keychain-db"
           ORIG_LIST="$(security list-keychains -d user | xargs)"
 
-          # Restore machine state even if an assertion aborts the step (set -e)
+          # Restore the search list and keychain even if an assertion aborts the step (set -e).
+          # The runner is ephemeral, so the trusted roots we plant below need no removal (and
+          # remove-trusted-cert can hang on an interactive auth prompt in CI).
           cleanup() {
             security list-keychains -d user -s $ORIG_LIST || true
             security delete-keychain "$KC" 2>/dev/null || true
-            sudo security remove-trusted-cert -d "$WORK/cA.pem" 2>/dev/null || true
-            sudo security remove-trusted-cert -d "$WORK/cB.pem" 2>/dev/null || true
           }
           trap cleanup EXIT
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,15 @@ jobs:
             echo "Keychain created"
           fi
 
+      - name: Check the keychain has no auto-lock timeout
+        run: |
+          INFO="$(security show-keychain-info "${{ steps.import.outputs.keychain-path }}" 2>&1)"
+          echo "$INFO"
+          echo "$INFO" | grep -q "no-timeout" || {
+            echo "::error::keychain should have no auto-lock timeout"
+            exit 1
+          }
+
   test-sign:
     name: TEST Sign
     runs-on: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,6 @@ name: tests
 on:
   push:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   test-no-cert:
     name: TEST inputs ${{ matrix.name }}
@@ -162,6 +158,25 @@ jobs:
           fi
           rm ${{ steps.unsigned.outputs.temp_file }}
 
+      - name: Check app-identity-hash output is a SHA-1 hash
+        run: |
+          if ! [[ "${{ steps.import.outputs.app-identity-hash }}" =~ ^[0-9A-F]{40}$ ]]; then
+            echo "::error::app-identity-hash is not a 40-char hex hash: '${{ steps.import.outputs.app-identity-hash }}'"
+            exit 1
+          fi
+
+      - name: Verify a file signed by identity hash
+        run: |
+          TEMP_FILE=$(mktemp)
+          codesign --force --sign "${{ steps.import.outputs.app-identity-hash }}" $TEMP_FILE -v --deep --strict --options=runtime --timestamp
+          codesign --verify -v $TEMP_FILE
+          if [ $? -ne 0 ]; then
+            echo "Code signing verification failed"
+            rm $TEMP_FILE
+            exit 1
+          fi
+          rm $TEMP_FILE
+
   test-installer-sign:
     name: TEST Installer Sign ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -199,10 +214,26 @@ jobs:
           productbuild --synthesize --package temp.pkg --sign "${{ secrets.DEVELOPER_ID_INSTALLER }}" --timestamp temp-product.pkg
           pkgutil --check-signature temp.pkg
 
+      - name: Check installer-identity-hash output is a SHA-1 hash
+        run: |
+          if ! [[ "${{ steps.import.outputs.installer-identity-hash }}" =~ ^[0-9A-F]{40}$ ]]; then
+            echo "::error::installer-identity-hash is not a 40-char hex hash: '${{ steps.import.outputs.installer-identity-hash }}'"
+            exit 1
+          fi
+
+      - name: Verify a pkg signed by identity hash
+        run: |
+          mkdir -p temp
+          TEMP_FILE=$(mktemp temp/XXXXXX)
+          echo "Hello World" > $TEMP_FILE
+          pkgbuild --root temp --identifier com.example.test --install-location ${{ runner.temp }} --sign "${{ steps.import.outputs.installer-identity-hash }}" --timestamp temp-hash.pkg
+          pkgutil --check-signature temp-hash.pkg
+
       - name: Cleanup
         run: |
           rm temp.pkg
           rm temp-product.pkg
+          rm temp-hash.pkg
 
   test-cleanup-after-sign:
     if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,6 +203,18 @@ jobs:
           set -eo pipefail
           NAME="Developer ID Application: Ambiguity Test (TESTTEAM00)"
           WORK="$(mktemp -d)"
+          KC="$HOME/Library/Keychains/ambiguity-test.keychain-db"
+          ORIG_LIST="$(security list-keychains -d user | xargs)"
+
+          # Restore machine state even if an assertion aborts the step (set -e)
+          cleanup() {
+            security list-keychains -d user -s $ORIG_LIST || true
+            security delete-keychain "$KC" 2>/dev/null || true
+            sudo security remove-trusted-cert -d "$WORK/cA.pem" 2>/dev/null || true
+            sudo security remove-trusted-cert -d "$WORK/cB.pem" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
           printf '[req]\ndistinguished_name=dn\nx509_extensions=ext\nprompt=no\n[dn]\nCN=%s\n[ext]\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning\n' "$NAME" > "$WORK/openssl.cnf"
 
           # two DIFFERENT certs (different keys) sharing one identity name
@@ -211,7 +223,6 @@ jobs:
             openssl pkcs12 -export -out "$WORK/$n.p12" -inkey "$WORK/k$n.pem" -in "$WORK/c$n.pem" -passout pass:pw
           done
 
-          KC="$HOME/Library/Keychains/ambiguity-test.keychain-db"
           security create-keychain -p pw "$KC"
           security unlock-keychain -p pw "$KC"
           for n in A B; do
@@ -223,8 +234,8 @@ jobs:
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cA.pem"
           sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cB.pem"
 
-          # codesign resolves -s by the search list, so the keychain must be in it (this is what the action's enable-keychain step does)
-          security list-keychains -d user -s "$KC"
+          # codesign resolves -s by the search list, so add (don't replace) the keychain, like the action's enable-keychain step
+          security list-keychains -d user -s "$KC" $ORIG_LIST
 
           echo "::group::valid codesigning identities"
           security find-identity -v -p codesigning "$KC"
@@ -249,10 +260,6 @@ jobs:
           echo "hash: $HASH"
           codesign --force -s "$HASH" "$VICTIM"
           echo "OK: signing by hash resolved the ambiguity"
-
-      - name: Cleanup
-        if: always()
-        run: security delete-keychain "$HOME/Library/Keychains/ambiguity-test.keychain-db" || true
 
   test-cleanup-after-sign:
     if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Since the convention on GitHub is that `@v1` is actually moving target, you migh
 Pick the latest tag, for example:
 
 ```
-  uses: sudara/basic-macos-keychain-action@v1.3.0
+  uses: sudara/basic-macos-keychain-action@v1.5.0
 ```
 
 On GitHub hosted runners, you would then sign an application or plugin just by referencing the identity:
@@ -70,14 +70,35 @@ And sign a pkg installer by referencing the installer identity:
 
 ```
 
-On self-hosted runners, you may want to to provide the `keychain-path` that this action outputs when signing. This will differentiate it from the local keychains:
+On self-hosted runners, your cert often already lives in your login keychain. You can pass the `keychain-path` that this action outputs to point `codesign` at the temporary keychain:
 
 ```bash
 codesign --force --keychain ${{ steps.keychain.outputs.keychain-path }} -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.ARTIFACT_PATH }}" --deep --strict --options=runtime --timestamp
 ```
 
+> [!WARNING]
+> `--keychain` does not stop `codesign` from also finding a same-named cert in your login keychain, so you can still hit `ambiguous (matches multiple identities)`. The reliable fix is to sign by the identity hash, see [Signing with the identity hash](#signing-with-the-identity-hash).
+
 > [!NOTE]
 > The `id` must be present to make use of `steps.keychain.outputs.keychain-path` when signing
+
+### Signing with the identity hash
+
+When the same cert already exists in another keychain (very common on self-hosted runners where it lives in your login keychain), `codesign` can find two identities with the same friendly name and bail out with `ambiguous (matches multiple identities)`.
+
+Passing `--keychain` narrows the search, but the most robust fix is to sign against the cert's SHA-1 hash, which points at one exact certificate. This action exposes that hash for you:
+
+```bash
+codesign --force -s "${{ steps.keychain.outputs.app-identity-hash }}" -v "${{ env.ARTIFACT_PATH }}" --deep --strict --options=runtime --timestamp
+```
+
+And for installers:
+
+```bash
+productbuild --synthesize --package "myTemporaryPkg" --distribution distribution.xml --sign "${{ steps.keychain.outputs.installer-identity-hash }}" --timestamp
+```
+
+The hash is the fingerprint of the cert itself, so it is stable across runs even though the keychain is recreated each time. You no longer need a `DEVELOPER_ID_APPLICATION` or `DEVELOPER_ID_INSTALLER` secret holding the identity name if you sign this way.
 
 ## Inputs
 
@@ -91,11 +112,15 @@ codesign --force --keychain ${{ steps.keychain.outputs.keychain-path }} -s "${{ 
 
 ## Outputs
 
-| Output          | Description                                       |
-| --------------- | ------------------------------------------------- |
-| `keychain-path` | Path to the temporary keychain with imported cert |
+| Output                    | Description                                                 |
+| ------------------------- | ----------------------------------------------------------- |
+| `keychain-path`           | Path to the temporary keychain with imported cert           |
+| `app-identity-hash`       | SHA-1 hash of the imported Developer ID Application identity |
+| `installer-identity-hash` | SHA-1 hash of the imported Developer ID Installer identity   |
 
-This path can specified for signing and is later used for cleanup.
+`keychain-path` can be specified for signing and is later used for cleanup.
+
+The two `*-identity-hash` outputs let you sign against the exact cert this action imported, instead of the friendly identity name. This sidesteps the dreaded `ambiguous (matches multiple identities)` error you hit when a same-named cert already lives in another keychain, which is common on self-hosted runners. See [Signing with the identity hash](#signing-with-the-identity-hash).
 
 ## How it works
 
@@ -152,13 +177,15 @@ You can view your keychains in your user directory `~/Library/Keychain`. You sho
 
 ### When your self-hosted runner is your local dev machine
 
-In this case, your certs probably already live in your local keychain.
+In this case, your certs already live in your login keychain, so the same-named cert now exists twice and `codesign` throws `ambiguous (matches multiple identities)`.
 
-To avoid dreaded "ambiguous" errors when using `codesign`, be sure to always specify the keychain you want to use when codesigning:
+Specifying `--keychain` is not enough on its own, since `codesign` still consults your login keychain and finds the duplicate. The reliable fix is to sign against the identity hash, which targets one exact cert:
 
 ```bash
-codesign --force --keychain ${{ steps.keychain.outputs.keychain-path }} # rest of command
+codesign --force -s "${{ steps.keychain.outputs.app-identity-hash }}" # rest of command
 ```
+
+See [Signing with the identity hash](#signing-with-the-identity-hash).
 
 > [!NOTE]
 > You must have provided an `id:` for the action (here it's `keychain`) to use the output, see Usage
@@ -178,10 +205,10 @@ If you are still having problems, open an issue.
 Putting this here to remember :)
 
 ```
-git tag -a v1.4.0 -m "Releasing 1.4.0"
+git tag -a v1.5.0 -m "Releasing 1.5.0"
 git push origin main --tags
 
 # Update the @v1
-git tag -f v1 v1.3.0
+git tag -f v1 v1.5.0
 git push -f origin v1
 ```

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.ARTIFAC
 And sign a pkg installer by referencing the `DEVELOPER_ID_INSTALLER` identity:
 
 ```bash
-  productbuild --synthesize --package "myTemporaryPkg" --distribution distribution.xml --sign "${{ secrets.DEVELOPER_ID_INSTALLER }}" --timestamp
-
+productsign --sign "${{ secrets.DEVELOPER_ID_INSTALLER }}" --timestamp unsigned.pkg signed.pkg
 ```
 
 On self-hosted runners, your cert often already lives in your login keychain. You can pass the `keychain-path` that this action outputs to point `codesign` at the temporary keychain:

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ codesign --force -s "${{ steps.keychain.outputs.app-identity-hash }}" -v "${{ en
 And for installers:
 
 ```bash
-productbuild --synthesize --package "myTemporaryPkg" --distribution distribution.xml --sign "${{ steps.keychain.outputs.installer-identity-hash }}" --timestamp
+pkgbuild --root "${{ env.PKG_ROOT }}" --identifier com.example.app --sign "${{ steps.keychain.outputs.installer-identity-hash }}" --timestamp output.pkg
 ```
 
-The hash is the fingerprint of the cert itself, so it is stable across runs even though the keychain is recreated each time. You no longer need a `DEVELOPER_ID_APPLICATION` or `DEVELOPER_ID_INSTALLER` secret holding the identity name if you sign this way.
+The hash is the fingerprint of the cert itself, so it is stable across runs even though the keychain is recreated each time. Read it from the action output each run rather than hardcoding it, since it changes if the cert is reissued. Signing this way, you no longer need a `DEVELOPER_ID_APPLICATION` or `DEVELOPER_ID_INSTALLER` secret holding the identity name.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ After running this action, you can now sign an application / plugin just by refe
 codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.ARTIFACT_PATH }}" --deep --strict --options=runtime --timestamp
 ```
 
-And sign a pkg installer by referencing the `DEVELOPER_ID_INSTALLER` identity:
+And sign a pkg installer by referencing the `DEVELOPER_ID_INSTALLER` identity. Build and sign a distribution installer in one step with `productbuild`:
+
+```bash
+productbuild --distribution distribution.xml --package-path . --sign "${{ secrets.DEVELOPER_ID_INSTALLER }}" --timestamp output.pkg
+```
+
+Or sign an already-built pkg with `productsign`:
 
 ```bash
 productsign --sign "${{ secrets.DEVELOPER_ID_INSTALLER }}" --timestamp unsigned.pkg signed.pkg

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,9 @@ runs:
         # Unlock it for use
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
+        # Drop the default 5-min auto-lock so a long job can't relock the keychain and hang codesign on a password prompt
+        security set-keychain-settings "$KEYCHAIN_PATH"
+
         # Set output for cleanup
         echo "keychain-path=$KEYCHAIN_PATH" >> $GITHUB_OUTPUT
         echo "keychain-password=$KEYCHAIN_PASSWORD" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,8 @@ runs:
         rm "$DEV_ID_APPLICATION"
 
         # The SHA-1 hash targets this exact cert, sidestepping ambiguity with same-named certs in other keychains
-        APP_IDENTITY_HASH=$(security find-identity -v -p codesigning "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Application" | awk '{print $2}')
+        # No -v: the temp keychain holds only the leaf cert, so the chain isn't validatable here, but the hash is
+        APP_IDENTITY_HASH=$(security find-identity -p codesigning "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Application" | awk '{print $2}' || true)
         if [ -z "$APP_IDENTITY_HASH" ]; then
           echo "::warning::Could not determine the Developer ID Application identity hash"
         fi
@@ -104,8 +105,8 @@ runs:
         # Clean up temp files
         rm "$DEV_ID_INSTALLER"
 
-        # Installer certs aren't a codesigning policy, so list all valid identities and pick the installer one
-        INSTALLER_IDENTITY_HASH=$(security find-identity -v "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Installer" | awk '{print $2}')
+        # Installer certs aren't a codesigning policy, so list all identities and pick the installer one
+        INSTALLER_IDENTITY_HASH=$(security find-identity "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Installer" | awk '{print $2}' || true)
         if [ -z "$INSTALLER_IDENTITY_HASH" ]; then
           echo "::warning::Could not determine the Developer ID Installer identity hash"
         fi

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,12 @@ outputs:
   keychain-path:
     description: 'Path to the temporary keychain with imported cert'
     value: ${{ steps.setup-keychain.outputs.keychain-path }}
+  app-identity-hash:
+    description: 'SHA-1 hash of the imported Developer ID Application identity. Sign with this to avoid ambiguity when a same-named cert exists in another keychain.'
+    value: ${{ steps.import-app-cert.outputs.app-identity-hash }}
+  installer-identity-hash:
+    description: 'SHA-1 hash of the imported Developer ID Installer identity. Sign with this to avoid ambiguity when a same-named cert exists in another keychain.'
+    value: ${{ steps.import-install-cert.outputs.installer-identity-hash }}
 
 
 runs:
@@ -77,6 +83,13 @@ runs:
         # Clean up temp files
         rm "$DEV_ID_APPLICATION"
 
+        # The SHA-1 hash targets this exact cert, sidestepping ambiguity with same-named certs in other keychains
+        APP_IDENTITY_HASH=$(security find-identity -v -p codesigning "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Application" | awk '{print $2}')
+        if [ -z "$APP_IDENTITY_HASH" ]; then
+          echo "::warning::Could not determine the Developer ID Application identity hash"
+        fi
+        echo "app-identity-hash=$APP_IDENTITY_HASH" >> $GITHUB_OUTPUT
+
     - id: import-install-cert
       if: inputs.dev-id-installer-cert != ''
       shell: bash
@@ -90,6 +103,13 @@ runs:
 
         # Clean up temp files
         rm "$DEV_ID_INSTALLER"
+
+        # Installer certs aren't a codesigning policy, so list all valid identities and pick the installer one
+        INSTALLER_IDENTITY_HASH=$(security find-identity -v "${{ steps.setup-keychain.outputs.keychain-path }}" | grep -m1 "Developer ID Installer" | awk '{print $2}')
+        if [ -z "$INSTALLER_IDENTITY_HASH" ]; then
+          echo "::warning::Could not determine the Developer ID Installer identity hash"
+        fi
+        echo "installer-identity-hash=$INSTALLER_IDENTITY_HASH" >> $GITHUB_OUTPUT
 
     - id: enable-keychain
       shell: bash


### PR DESCRIPTION
In self-hosted environments that double as a local dev machine, importing the codesigning identities can lead to dreaded `ambiguous` errors from apple.

Adds 

| `app-identity-hash`       | SHA-1 hash of the imported Developer ID Application identity |
| `installer-identity-hash` | SHA-1 hash of the imported Developer ID Installer identity   |


which lets you do

```bash
codesign --force -s "${{ steps.keychain.outputs.app-identity-hash }}" -v "${{ env.ARTIFACT_PATH }}" --deep --strict --options=runtime --timestamp
```

And for installers:

```bash
productbuild --synthesize --package "myTemporaryPkg" --distribution distribution.xml --sign "${{ steps.keychain.outputs.installer-identity-hash }}" --timestamp
```